### PR TITLE
Fix of error when value is Number + style fixes

### DIFF
--- a/src/mask.js
+++ b/src/mask.js
@@ -1,15 +1,13 @@
 
-export default function mask(value, precision, decimalSeparator, thousandSeparator, allowNegative, prefix, suffix){
+export default function mask(value, precision = 2, decimalSeparator = '.', thousandSeparator = ',', allowNegative = false, prefix = '', suffix = ''){
     // provide some default values and arg validation.
-    if (decimalSeparator === undefined){decimalSeparator = ".";} // default to '.' as decimal separator
-    if (thousandSeparator === undefined){thousandSeparator = ",";} // default to ',' as thousand separator
-    if (allowNegative === undefined){allowNegative = false;} // default to not allowing negative numbers
-    if (precision === undefined){precision = 2;} // by default, 2 decimal places
-    if (precision < 0) {precision = 0;} // precision cannot be negative.
-    if (precision > 20) {precision = 20;} // precision cannot greater than 20
-    if (prefix === undefined){prefix = '';} // default prefix to empty string
-    if (suffix === undefined){suffix = '';} // default suffix to empty string
+    if (precision < 0) { precision = 0; } // precision cannot be negative
+    if (precision > 20) { precision = 20; } // precision cannot be greater than 20
+    value = String(value); //if the given value is a Number, let's convert into String to manipulate that
 
+    // extract digits. if no digits, fill in a zero.
+    let digits = value.match(/\d/g) || ['0'];
+    
     let numberIsNegative = false;
     if (allowNegative) {
         let negativeSignCount = (value.match(/-/g) || []).length;
@@ -17,30 +15,24 @@ export default function mask(value, precision, decimalSeparator, thousandSeparat
         // ideally, we should only ever have 0, 1 or 2 (positive number, making a number negative
         // and making a negative number positive, respectively)
         numberIsNegative = negativeSignCount % 2 === 1;
-    }
-
-    // extract digits. if no digits, fill in a zero.
-    let digits = value.match(/\d/g) || ['0'];
-
-    if (allowNegative) {
-        // if every digit in the array is '0', then the number should
-        // never be negative
+        
+        // if every digit in the array is '0', then the number should never be negative
         let allDigitsAreZero = true;
-        for(let idx=0; idx < digits.length; idx += 1) {
+        for (let idx=0; idx < digits.length; idx += 1) {
             if(digits[idx] !== '0') {
                 allDigitsAreZero = false;
                 break;
             }
         }
-        if(allDigitsAreZero) {
+        if (allDigitsAreZero) {
             numberIsNegative = false;
         }
     }
 
     // zero-pad a input
-    while (digits.length <= precision) {digits.unshift('0')}
+    while (digits.length <= precision) { digits.unshift('0'); }
 
-    if (precision > 0){
+    if (precision > 0) {
         // add the decimal separator
         digits.splice(digits.length - precision, 0, ".");
     }
@@ -53,19 +45,19 @@ export default function mask(value, precision, decimalSeparator, thousandSeparat
     if (precision > 0) {
         // set the final decimal separator
         digits[decimalpos] = decimalSeparator;
-    }else{
+    } else {
         // when precision is 0, there is no decimal separator.
-        decimalpos = digits.length
+        decimalpos = digits.length;
     }
 
     // add in any thousand separators
-    for (let x=decimalpos - 3; x > 0; x = x - 3){
+    for (let x=decimalpos - 3; x > 0; x = x - 3) {
         digits.splice(x, 0, thousandSeparator);
     }
 
     // if we have a prefix or suffix, add them in.
-    if (prefix.length > 0){digits.unshift(prefix);}
-    if (suffix.length > 0){digits.push(suffix);}
+    if (prefix.length > 0) { digits.unshift(prefix); }
+    if (suffix.length > 0) { digits.push(suffix); }
 
     // if the number is negative, insert a "-" to
     // the front of the array


### PR DESCRIPTION
- When the given value is a Number the component errored out when calling match() on it. _I decided to convert it instead of force it to be a String on the component's propTypes because: 1 backwards-compat; 2 more flexibility for those implementing the component_
- Several code style improvements, using some sort of spacing and semicolon standard
- Setting default arguments where they belong: in the function signature