### PR TITLE
Documenting allowEmpty

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ All other attributes are applied to the input element.  For example, you can int
 | precision         | 2             | Number of digits after the decimal separator |
 | decimalSeparator  | '.'           | The decimal separator |
 | thousandSeparator | ','           | The thousand separator |
-| inputType         | "text"        | Input field tag type. You may want to use `number` or `tel` |
+| inputType         | "text"        | Input field tag type. You may want to use `number` or `tel`* |
 | allowNegative     | false         | Allows negative numbers in the input |
+| allowEmpty        | false         | If no `value` is given, defines if it starts as null (`true`) or '' (`false`) |
 | prefix            | ''            | Currency prefix |
 | suffix            | ''            | Currency suffix |
 
 
-**Note:** Enabling any mask-related features such as prefix, suffix or separators 
+__*Note:__ Enabling any mask-related features such as prefix, suffix or separators 
 with an inputType="number" or "tel" could trigger errors. Most of those characters
  would be invalid in such input types.


### PR DESCRIPTION
Also, adding a star pointing to the inputType observation.

But actually, what's the purpose of `allowEmpty` anyway? If the user doesn't input anything, deciding if it should be a null value or an empty string?

> PS: the default value for allowEmpty is actually null, but the effect is the same as false, so...