### PR TITLE
Fire onChange event only after state updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,8 +157,9 @@ const CurrencyInput = React.createClass({
             this.props.prefix,
             this.props.suffix
         );
-        this.setState({ maskedValue, value });
-        this.props.onChange(maskedValue, value, event);
+        this.setState({ maskedValue, value }, () => {
+            this.props.onChange(maskedValue, value, event);
+        });
     },
 
 


### PR DESCRIPTION
setState doesn't immediately update the components state.  A callback can be specified when calling setState for when the state changes are processed.  This fixes a problem where for some reason you need to access the currency input directly to get its value, e.g. this.refs.currencyInput.getMaskedValue().