### PR TITLE
Replace built in PropTypes from React core with stand-alone package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,10 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -29,16 +33,16 @@ var CurrencyInput = _react2.default.createClass({
      * @see https://facebook.github.io/react/docs/component-specs.html#proptypes
      */
     propTypes: {
-        onChange: _react.PropTypes.func,
-        value: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.string]),
-        decimalSeparator: _react.PropTypes.string,
-        thousandSeparator: _react.PropTypes.string,
-        precision: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.string]),
-        inputType: _react.PropTypes.string,
-        allowNegative: _react.PropTypes.bool,
-        allowEmpty: _react.PropTypes.bool,
-        prefix: _react.PropTypes.string,
-        suffix: _react.PropTypes.string
+        onChange: _propTypes2.default.func,
+        value: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string]),
+        decimalSeparator: _propTypes2.default.string,
+        thousandSeparator: _propTypes2.default.string,
+        precision: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string]),
+        inputType: _propTypes2.default.string,
+        allowNegative: _propTypes2.default.bool,
+        allowEmpty: _propTypes2.default.bool,
+        prefix: _propTypes2.default.string,
+        suffix: _propTypes2.default.string
     },
 
     /**
@@ -114,11 +118,9 @@ var CurrencyInput = _react2.default.createClass({
             });
         }
 
-        var _mask = (0, _mask4.default)(initialValue, props.precision, props.decimalSeparator, props.thousandSeparator, props.allowNegative, props.prefix, props.suffix);
-
-        var maskedValue = _mask.maskedValue;
-        var value = _mask.value;
-
+        var _mask = (0, _mask4.default)(initialValue, props.precision, props.decimalSeparator, props.thousandSeparator, props.allowNegative, props.prefix, props.suffix),
+            maskedValue = _mask.maskedValue,
+            value = _mask.value;
 
         return { maskedValue: maskedValue, value: value, customProps: customProps };
     },
@@ -156,6 +158,34 @@ var CurrencyInput = _react2.default.createClass({
     getMaskedValue: function getMaskedValue() {
         return this.state.maskedValue;
     },
+    componentDidMount: function componentDidMount() {
+        var node = _reactDom2.default.findDOMNode(this.theInput);
+
+        var selectionEnd = Math.min(node.selectionEnd, this.theInput.value.length - this.props.suffix.length);
+        var selectionStart = Math.min(node.selectionStart, selectionEnd);
+        //console.log("normal", selectionStart, selectionEnd);
+        node.setSelectionRange(selectionStart, selectionEnd);
+    },
+    componentDidUpdate: function componentDidUpdate(prevProps, prevState) {
+
+        var node = _reactDom2.default.findDOMNode(this.theInput);
+        var selectionEnd = Math.min(this.state.selectionEnd, this.theInput.value.length - this.props.suffix.length);
+        var selectionStart = Math.min(this.state.selectionStart, selectionEnd);
+
+        // moves the cursor to the right when digits are added.
+        var adjustment = Math.max(this.state.maskedValue.length - prevState.maskedValue.length - 1, 0);
+
+        var baselength = this.props.suffix.length + this.props.prefix.length + this.props.decimalSeparator.length + Number(this.props.precision) + 1; // This is to account for the default '0' value that comes before the decimal separator
+
+        if (this.state.maskedValue.length == baselength) {
+            // if we are already at base length, position the cursor at the end.
+            selectionEnd = this.theInput.value.length - this.props.suffix.length;
+            selectionStart = selectionEnd;
+            adjustment = 0;
+        }
+
+        node.setSelectionRange(selectionStart + adjustment, selectionEnd + adjustment);
+    },
 
 
     /**
@@ -163,15 +193,21 @@ var CurrencyInput = _react2.default.createClass({
      * @param event
      */
     handleChange: function handleChange(event) {
+        var _this = this;
+
         event.preventDefault();
 
-        var _mask2 = (0, _mask4.default)(event.target.value, this.props.precision, this.props.decimalSeparator, this.props.thousandSeparator, this.props.allowNegative, this.props.prefix, this.props.suffix);
+        var _mask2 = (0, _mask4.default)(event.target.value, this.props.precision, this.props.decimalSeparator, this.props.thousandSeparator, this.props.allowNegative, this.props.prefix, this.props.suffix),
+            maskedValue = _mask2.maskedValue,
+            value = _mask2.value;
 
-        var maskedValue = _mask2.maskedValue;
-        var value = _mask2.value;
+        var node = _reactDom2.default.findDOMNode(this.theInput);
+        var selectionEnd = Math.min(node.selectionEnd, this.theInput.value.length - this.props.suffix.length);
+        var selectionStart = Math.min(node.selectionStart, selectionEnd);
 
-        this.setState({ maskedValue: maskedValue, value: value });
-        this.props.onChange(maskedValue, value, event);
+        this.setState({ maskedValue: maskedValue, value: value }, function () {
+            _this.props.onChange(maskedValue, value, event);
+        });
     },
 
 
@@ -181,24 +217,18 @@ var CurrencyInput = _react2.default.createClass({
      */
     handleFocus: function handleFocus(event) {
         //Whenever we receive focus check to see if the position is before the suffix, if not, move it.
-
-        // if there is no suffix, then no worries just return
-        if (this.props.suffix.length == 0) {
-            console.log("No suffix.");
-            return;
-        }
-
-        console.log("Select Start", event.target.selectionStart);
-        console.log("Select End", event.target.selectionEnd);
-
-        var selectionEnd = Math.min(event.target.selectionEnd, event.target.value.length - this.props.suffix.length);
-        var selectionStart = Math.min(event.target.selectionStart, selectionEnd);
-
+        var selectionEnd = this.theInput.value.length - this.props.suffix.length;
+        var selectionStart = this.props.prefix.length;
         console.log(selectionStart, selectionEnd);
-
-        this.theInput.setSelectionRange(selectionStart, selectionEnd);
+        event.target.setSelectionRange(selectionStart, selectionEnd);
+        this.setState({ selectionStart: selectionStart, selectionEnd: selectionEnd });
     },
-    handleBlur: function handleBlur(event) {},
+    handleBlur: function handleBlur(event) {
+        this.setState({
+            selectionStart: null,
+            selectionEnd: null
+        });
+    },
 
 
     /**
@@ -207,17 +237,17 @@ var CurrencyInput = _react2.default.createClass({
      * @see https://facebook.github.io/react/docs/component-specs.html#render
      */
     render: function render() {
-        var _this = this;
+        var _this2 = this;
 
         return _react2.default.createElement('input', _extends({
             ref: function ref(input) {
-                _this.theInput = input;
+                _this2.theInput = input;
             },
             type: this.props.inputType,
             value: this.state.maskedValue,
             onChange: this.handleChange,
             onFocus: this.handleFocus,
-            onBlur: this.handleBlur
+            onMouseUp: this.handleFocus
         }, this.state.customProps));
     }
 });

--- a/lib/mask.js
+++ b/lib/mask.js
@@ -5,12 +5,12 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = mask;
 function mask(value) {
-    var precision = arguments.length <= 1 || arguments[1] === undefined ? 2 : arguments[1];
-    var decimalSeparator = arguments.length <= 2 || arguments[2] === undefined ? '.' : arguments[2];
-    var thousandSeparator = arguments.length <= 3 || arguments[3] === undefined ? ',' : arguments[3];
-    var allowNegative = arguments.length <= 4 || arguments[4] === undefined ? false : arguments[4];
-    var prefix = arguments.length <= 5 || arguments[5] === undefined ? '' : arguments[5];
-    var suffix = arguments.length <= 6 || arguments[6] === undefined ? '' : arguments[6];
+    var precision = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
+    var decimalSeparator = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '.';
+    var thousandSeparator = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : ',';
+    var allowNegative = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
+    var prefix = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : '';
+    var suffix = arguments.length > 6 && arguments[6] !== undefined ? arguments[6] : '';
 
     // provide some default values and arg validation.
     if (precision < 0) {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint": "^2.13.1",
     "jsdom": "^9.2.1",
     "mocha": "^2.5.3",
+    "prop-types": "^15.5.9",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0",
     "rimraf": "^2.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types';
+import React from 'react'
 import ReactDOM from 'react-dom'
 import mask from './mask.js'
 


### PR DESCRIPTION
This should fix the warning `Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.` and prepare us for the release of React 16.