### PR TITLE
Remove sinon from dependencies and correct prop-types peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/jsillitoe/react-currency-input#readme",
   "peerDependencies": {
-    "prop-types": "^16.0.0",
+    "prop-types": "^15.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
@@ -77,8 +77,6 @@
     "browserify": "13.3.0",
     "jsdom": "9.12.0",
     "prop-types": "15.6.0",
-    "rimraf": "2.6.2",
-    "sinon": "1.17.7",
-    "sinon-chai": "2.14.0"
+    "rimraf": "2.6.2"
   }
 }


### PR DESCRIPTION
Fixes warnings when installing the package

```
warning " > react-currency-input@1.3.6" has incorrect peer dependency "prop-types@^16.0.0".
warning "react-currency-input > sinon-chai@2.14.0" has unmet peer dependency "chai@>=1.9.2 <5".
```