### PR TITLE
Fix focus issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ class CurrencyInput extends Component {
         this.prepareProps = this.prepareProps.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleFocus = this.handleFocus.bind(this);
+        this.setSelectionRange = this.setSelectionRange.bind(this);
         this.state = this.prepareProps(this.props);
 
         this.inputSelectionStart = 1;
@@ -130,7 +131,7 @@ class CurrencyInput extends Component {
             selectionStart = Math.min(node.selectionStart, selectionEnd);
         }
 
-        node.setSelectionRange(selectionStart, selectionEnd);
+        this.setSelectionRange(node, selectionStart, selectionEnd);
     }
 
 
@@ -182,9 +183,21 @@ class CurrencyInput extends Component {
             selectionStart = selectionEnd;
         }
 
-        node.setSelectionRange(selectionStart, selectionEnd);
+        this.setSelectionRange(node, selectionStart, selectionEnd);
         this.inputSelectionStart = selectionStart;
         this.inputSelectionEnd = selectionEnd;
+    }
+
+    /**
+     * Set selection range only if input is in focused state
+     * @param node DOMElement
+     * @param start number
+     * @param end number
+     */
+    setSelectionRange(node, start, end) {
+      if (document.activeElement === node) {
+        node.setSelectionRange(start, end);
+      }
     }
 
 


### PR DESCRIPTION
Fixes #74 

`node.setSelectionRange` caused focus jump in Safari and mobile browsers. The solution is to set selection only if the input is in the active (focused) state to not interfere with other inputs.