### PR TITLE
Export mask function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -308,3 +308,5 @@ CurrencyInput.defaultProps = {
 
 
 export default CurrencyInput
+
+export { mask };


### PR DESCRIPTION
I've stumbled upon a case in which the `mask` function is useful by itself.

What I needed was to generate a plain text output of a currency, but formatted exactly like in the input component (same `precision`, `decimalSeparator`, etc.). By exporting the `mask` function, I can just import that and call it with the same parameters as I did for the input component, and _voilà_: we have a formatted, plain text output.